### PR TITLE
Add ReplClear command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Use `g:repl_default` to set the default repl if no configured repl is found in `
 
 `:ReplToggle`: if repl is open, close it. If repl is closed, open it using either the filetype-associated repl or the configured default repl.
 
+`:ReplClear`: clear the repl, if open.
+
 ## Notes
 
 This plugin prioritizes simplicity and ease of use on a POSIX-compliant system. Support for Windows and other non-Unix derivatives is out of scope.

--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -107,3 +107,11 @@ function! repl#send() range
   call chansend(s:id_job, buflines_chansend)
   call s:repl_reset_visual_position()
 endfunction
+
+function! repl#clear()
+  if s:id_window == v:false
+    echom 'Repl: no repl currently open. Run ":ReplOpen" first'
+    return
+  endif
+  call chansend(s:id_job, "\<c-l>")
+endfunction

--- a/doc/repl.txt
+++ b/doc/repl.txt
@@ -59,6 +59,8 @@ particular filetype.
 *:ReplToggle*
   if repl is open, close it. If repl is closed, open it using either the
   filetype-associated repl or the configured default repl.
+*:ReplClose*
+  clear the repl, if open.
 
 ==============================================================================
                                                                 *repl_mappings*

--- a/plugin/repl.vim
+++ b/plugin/repl.vim
@@ -73,6 +73,9 @@ endif
 if !s:exists(':ReplSend')
   command! -range ReplSend <line1>,<line2>call repl#send()
 endif
+if !s:exists('ReplClear')
+  command! ReplClear call repl#clear()
+endif
 
 " Pluggable mappings
 


### PR DESCRIPTION
The ReplClear commands clears the current repl via the repl#clear
function. This function sends CTRL-l to the current repl, which should
clear most repls. Some mapping of filetype to repl clear command could
be useful in handling non standard repls.

I wanted this functionality, got something working locally, so thought I would share. But not sure if this is the best approach.