### PR TITLE
Add repl window configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,20 @@ let g:repl_filetype_commands = {
 Use `g:repl_default` to set the default repl if no configured repl is found in `g:repl_filetype_commands`. Defaults to `&shell`.
 
 Use `g:repl_position` to set the repl window position.
-- 0 split bottom (default)
-- 1 split right
+- 0: split bottom
+- 1: split top
+- 2: split left
+- 3: split right (default)
 
-If split right is prefered, then add below line to configuration.
+If split bottom is prefered, then add below line to configuration.
 
 ```vim
-let g:repl_position = 1
+let g:repl_position = 0
 ```
 
-Use `g:repl_height` to set repl window's height (number of lines) if `g:repl_position` set 0. Default will split equally
+Use `g:repl_height` to set repl window's height (number of lines) if `g:repl_position` set 0/1. Default will split equally
 
-Use `g:repl_width` to set repl window's width (number of columns) if `g:repl_position` set 1. Default will vsplit equally.
+Use `g:repl_width` to set repl window's width (number of columns) if `g:repl_position` set 2/3. Default will vsplit equally.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -64,21 +64,21 @@ let g:repl_filetype_commands = {
 
 Use `g:repl_default` to set the default repl if no configured repl is found in `g:repl_filetype_commands`. Defaults to `&shell`.
 
-Use `g:repl_position` to set the repl window position.
-- 0: split bottom
-- 1: split top
-- 2: split left
-- 3: split right (default)
+Use `g:repl_split` to set the repl window position.
+- `'bottom'`
+- `'top'`
+- `'left'`
+- `'right'` (default)
 
 If split bottom is prefered, then add below line to configuration.
 
 ```vim
-let g:repl_position = 0
+let g:repl_split = 'bottom'
 ```
 
-Use `g:repl_height` to set repl window's height (number of lines) if `g:repl_position` set 0/1. Default will split equally
+Use `g:repl_height` to set repl window's height (number of lines) if `g:repl_split` set `'bottom'`/`'top'`. Default will split equally.
 
-Use `g:repl_width` to set repl window's width (number of columns) if `g:repl_position` set 2/3. Default will vsplit equally.
+Use `g:repl_width` to set repl window's width (number of columns) if `g:repl_split` set `'left'`/`'right'`. Default will vsplit equally.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ let g:repl_filetype_commands = {
 
 Use `g:repl_default` to set the default repl if no configured repl is found in `g:repl_filetype_commands`. Defaults to `&shell`.
 
+Use `g:repl_position` to set the repl window position.
+- 0 split bottom (default)
+- 1 split right
+
+If split right is prefered, then add below line to configuration.
+
+```vim
+let g:repl_position = 1
+```
+
+Use `g:repl_height` to set repl window's height (number of lines) if `g:repl_position` set 0. Default will split equally
+
+Use `g:repl_width` to set repl window's width (number of columns) if `g:repl_position` set 1. Default will vsplit equally.
+
 ## Commands
 
 `:Repl` or `:ReplOpen`: open the repl. Takes the name of an executable repl as an optional argument. If no argument is provided, defaults to either the filetype-associated repl or the configured default repl.

--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -48,10 +48,14 @@ function! repl#open(...)
   let command = len(func_args) == 0 ?
         \ get(g:repl_filetype_commands, &filetype, g:repl_default) :
         \ func_args[0]
-  if &columns >= 160
-    vert new
-  else
-    split new
+  " default value for win position and w/h
+  let g:repl_position = get(g:, 'repl_position', 0)
+  let g:repl_height = get(g:, 'repl_height', '')
+  let g:repl_width = get(g:, 'repl_width', '')
+  if g:repl_position == 0
+    execute g:repl_height."split new"
+  elseif g:repl_position == 1
+    execute "vert ".g:repl_width."new"
   endif
   let s:id_job = termopen(command)
   let s:id_window = win_getid()

--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -49,21 +49,21 @@ function! repl#open(...)
         \ get(g:repl_filetype_commands, &filetype, g:repl_default) :
         \ func_args[0]
   " default value for win position and w/h
-  let g:repl_position = get(g:, 'repl_position', 3)
+  let g:repl_split = get(g:, 'repl_split', 'right')
   let g:repl_height = get(g:, 'repl_height', '')
   let g:repl_width = get(g:, 'repl_width', '')
-  if g:repl_position == 0
+  if g:repl_split == 'bottom'
     setlocal splitbelow
-    execute g:repl_height."split new"
-  elseif g:repl_position == 1
+    execute g:repl_height.'split new'
+  elseif g:repl_split == 'top'
     setlocal nosplitbelow
-    execute g:repl_height."split new"
-  elseif g:repl_position == 2
+    execute g:repl_height.'split new'
+  elseif g:repl_split == 'left'
     setlocal nosplitright
-    execute "vert ".g:repl_width."new"
-  elseif g:repl_position == 3
+    execute 'vert '.g:repl_width.'new'
+  elseif g:repl_split == 'right'
     setlocal splitright
-    execute "vert ".g:repl_width."new"
+    execute 'vert '.g:repl_width.'new'
   endif
   let s:id_job = termopen(command)
   let s:id_window = win_getid()

--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -49,12 +49,20 @@ function! repl#open(...)
         \ get(g:repl_filetype_commands, &filetype, g:repl_default) :
         \ func_args[0]
   " default value for win position and w/h
-  let g:repl_position = get(g:, 'repl_position', 0)
+  let g:repl_position = get(g:, 'repl_position', 3)
   let g:repl_height = get(g:, 'repl_height', '')
   let g:repl_width = get(g:, 'repl_width', '')
   if g:repl_position == 0
+    setlocal splitbelow
     execute g:repl_height."split new"
   elseif g:repl_position == 1
+    setlocal nosplitbelow
+    execute g:repl_height."split new"
+  elseif g:repl_position == 2
+    setlocal nosplitright
+    execute "vert ".g:repl_width."new"
+  elseif g:repl_position == 3
+    setlocal splitright
     execute "vert ".g:repl_width."new"
   endif
   let s:id_job = termopen(command)

--- a/doc/repl.txt
+++ b/doc/repl.txt
@@ -47,20 +47,20 @@ The default repl selected. Used when no configured repl is found for a
 particular filetype.
 
 *g:repl_position*
-Type: Int
+Type: Number
 Default: 0
 
 Set the position of repl window. Set `0` to split bottom and set `1` to split
 right.
 
 *g:repl_height*
-Type: Int
+Type: Number
 Default: ''
 
 Set repl window's height (number of lines) if `g:repl_position` set 0.
 
 *g:repl_width*
-Type: Int
+Type: Number
 Default: ''
 
 Set repl window's width (number of columns) if `g:repl_position` set 1.

--- a/doc/repl.txt
+++ b/doc/repl.txt
@@ -48,22 +48,26 @@ particular filetype.
 
 *g:repl_position*
 Type: Number
-Default: 0
+Default: 3
 
-Set the position of repl window. Set `0` to split bottom and set `1` to split
-right.
+Set the position of repl window.  Default split right. >
+
+  - 0: split bottom
+  - 1: split top
+  - 2: split left
+  - 3: split right
 
 *g:repl_height*
 Type: Number
 Default: ''
 
-Set repl window's height (number of lines) if `g:repl_position` set 0.
+Set repl window's height (number of lines) if `g:repl_position` set 0/1.
 
 *g:repl_width*
 Type: Number
 Default: ''
 
-Set repl window's width (number of columns) if `g:repl_position` set 1.
+Set repl window's width (number of columns) if `g:repl_position` set 2/3.
 
 ==============================================================================
                                                                 *repl_commands*

--- a/doc/repl.txt
+++ b/doc/repl.txt
@@ -46,6 +46,25 @@ Default: &shell
 The default repl selected. Used when no configured repl is found for a
 particular filetype.
 
+*g:repl_position*
+Type: Int
+Default: 0
+
+Set the position of repl window. Set `0` to split bottom and set `1` to split
+right.
+
+*g:repl_height*
+Type: Int
+Default: ''
+
+Set repl window's height (number of lines) if `g:repl_position` set 0.
+
+*g:repl_width*
+Type: Int
+Default: ''
+
+Set repl window's width (number of columns) if `g:repl_position` set 1.
+
 ==============================================================================
                                                                 *repl_commands*
 3. COMMANDS~

--- a/doc/repl.txt
+++ b/doc/repl.txt
@@ -46,28 +46,29 @@ Default: &shell
 The default repl selected. Used when no configured repl is found for a
 particular filetype.
 
-*g:repl_position*
-Type: Number
-Default: 3
+*g:repl_split*
+Type: String
+Default: 'right'
 
-Set the position of repl window.  Default split right. >
+Set the split position of repl window. Default will split right.
+Available options: >
 
-  - 0: split bottom
-  - 1: split top
-  - 2: split left
-  - 3: split right
+  - 'bottom'
+  - 'top'
+  - 'left'
+  - 'right'
 
 *g:repl_height*
 Type: Number
 Default: ''
 
-Set repl window's height (number of lines) if `g:repl_position` set 0/1.
+Set repl window's height (number of lines) if `g:repl_split` set 'bottom'/'top'.
 
 *g:repl_width*
 Type: Number
 Default: ''
 
-Set repl window's width (number of columns) if `g:repl_position` set 2/3.
+Set repl window's width (number of columns) if `g:repl_split` set 'left'/'right'.
 
 ==============================================================================
                                                                 *repl_commands*


### PR DESCRIPTION
These are some improvements of customizing repl windows, including:

- Add `g:repl_position` variable to set the location where repl windows will appear.
Available value consist of 0(bottom), 1(top), 2(left) and 3(right/default).
- Add `g:repl_height` and `g:repl_width` to set the repl window's height and width if bottom/top and left/right by fixed lines number. If variables aren't set, repl window will split equally.

These configs are just what I want to customize. But not sure if this is best way for the plugin.

Tested on nvim v0.5.0