### PR TITLE
[FIX]: the bug when using powershell as default shell will lead crush

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,19 @@ Two pluggable mappings are provided. They rely on the latest version of Tim Pope
 
 `<Plug>ReplSendVisual` send the visual selection to the repl. Only mappable in visual mode.
 
-The user should map these pluggable mappings. Example mappings:
+The user should map these pluggable mappings. Example mappings in config using vim filetype :
 
 ```vim
 nnoremap <leader>rt :ReplToggle<CR>
 nnoremap <leader>rc :ReplRunCell<CR>
 nmap <leader>rr <Plug>ReplSendLine
 vmap <leader>rr <Plug>ReplSendVisual
+```
+or use lua format:
+```lua
+["<leader>rt"] = { "<cmd>ReplToggle<cr>", desc = "Toggle nvim-repl" },
+["<leader>rr"] = { "<cmd>ReplSend<cr>", desc = "nvim-repl send current line" },
+["<leader>rc"] = { "<cmd>ReplRunCell<cr>", desc = "nvim-repl run cell" },
 ```
 
 ## :gear:Configurations

--- a/README.md
+++ b/README.md
@@ -66,12 +66,6 @@ nnoremap <leader>rc :ReplRunCell<CR>
 nmap <leader>rr <Plug>ReplSendLine
 vmap <leader>rr <Plug>ReplSendVisual
 ```
-or use lua format:
-```lua
-["<leader>rt"] = { "<cmd>ReplToggle<cr>", desc = "Toggle nvim-repl" },
-["<leader>rr"] = { "<cmd>ReplSend<cr>", desc = "nvim-repl send current line" },
-["<leader>rc"] = { "<cmd>ReplRunCell<cr>", desc = "nvim-repl run cell" },
-```
 
 ## :gear:Configurations
 
@@ -100,7 +94,6 @@ let g:repl_filetype_commands = {
   - `'vertical'` (default)
 
   If split bottom is preferred, then add below line to configuration.
-
   ```vim
   let g:repl_split = 'bottom'
   ```
@@ -108,6 +101,25 @@ let g:repl_filetype_commands = {
   Use `g:repl_height` to set repl window's height (number of lines) if `g:repl_split` set `'bottom'`/`'top'`. Default will split equally.
 
   Use `g:repl_width` to set repl window's width (number of columns) if `g:repl_split` set `'left'`/`'right'`. Default will vsplit equally.
+
+### the sample example for [lazyvim](https://github.com/folke/lazy.nvim)
+
+```lua
+{
+  "ACupofAir/nvim-repl",
+  init = function()
+    vim.g["repl_filetype_commands"] = {
+      javascript = "node",
+      python = "ipython --no-autoindent"
+    }
+  end,
+  keys = {
+    { "<leader>rt", "<cmd>ReplToggle<cr>", desc = "Toggle nvim-repl" },
+    { "<leader>rc", "<cmd>ReplRunCell<cr>", desc = "nvim-repl run cell" },
+  },
+}
+```
+
 
 ## :question:FAQ
 

--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -72,10 +72,15 @@ function! repl#open(...)
   else
     throw 'Something went wrong, file issue with https://github.com/pappasam/nvim-repl...'
   endif
+  let s:old_shell = &shell
+  if s:old_shell == 'powershell'
+    set shell=cmd
+  endif
   let s:id_job = termopen(command)
   let s:id_window = win_getid()
   call s:setup()
   call win_gotoid(current_window_id)
+  let &shell=s:old_shell
   echom 'repl: opened!'
 endfunction
 


### PR DESCRIPTION
## Why Changes
In neovim, the default shell set as powershell(vim.opt.shell="powershell"). It has some thing error when try to open term with args.
reproduce: firstly, `set shell=powershell`; then`:vsp|term ipython`. The term winodws will don't open ipython rightly. But when shell set to cmd, the problem will don't appeal. I guess may be the powershell is a pamameter for cmd, and it can't handle any args more after termopen for it had token 'powershell' as its arg.

## Changes
* update `readme.md`: add lazy.nvim configure template.
* update`autoload/repl.vim`: change the shell to cmd to open the repl, and restore to default shell after repl opened.