### PR TITLE
Add support for ipython's multiline functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ xmap <silent> <Leader>r <Plug>(ReplSendVisual)
         \ 'javascript': 'node',
         \ 'haskell': 'ghci',
         \ 'ocaml': #{cmd: 'utop', suffix: ';;'},
-        \ 'python': 'ipython --no-autoindent',
+        \ 'python': #{cmd: 'ipython --no-autoindent', repl_type: 'ipython'},
         \ 'r': 'R',
         \ 'sh': 'sh',
         \ 'vim': 'nvim --clean -ERM',

--- a/autoload/repl.vim
+++ b/autoload/repl.vim
@@ -95,7 +95,7 @@ function! repl#open(...)
   endif
   let current_window_id = win_getid()
   if a:0 > 0
-    let repl = #{cmd: a:1, prefix: s:dequote(get(a:, 2, '')), suffix: s:dequote(get(a:, 3, '')), repl_type: s:dequote(get(a:, 3, ''))}
+    let repl = #{cmd: a:1, prefix: s:dequote(get(a:, 2, '')), suffix: s:dequote(get(a:, 3, '')), repl_type: s:dequote(get(a:, 4, ''))}
   else
     let repl = s:get_repl_from_config()
   endif

--- a/doc/repl.txt
+++ b/doc/repl.txt
@@ -52,8 +52,8 @@ keys are:
 - `repl_type` unlocks different repl behaviors ('' uses default behavior).
   Supported repl types are:
   - `default`: sends lines, 1 at a time, to the repl for evaluation.
-  - `ipython`: similar to default, but uses system clipboard and %paste if
-    multiple lines are being sent to the repl.
+  - `ipython`: similar to default, but enters ipython's special multiline mode
+    with <C-o> if more than 1 line is sent to the repl.
 
 If its value is a String, the value is the `cmd`. All other options are `''`.
 

--- a/doc/repl.txt
+++ b/doc/repl.txt
@@ -34,7 +34,7 @@ this: >vim
         \ 'javascript': 'node',
         \ 'haskell': 'ghci',
         \ 'ocaml': #{cmd: 'utop', suffix: ';;'},
-        \ 'python': 'ipython --quiet --no-autoindent',
+        \ 'python': #{cmd: 'ipython --no-autoindent', repl_type: 'ipython'},
         \ 'r': 'R',
         \ 'sh': 'sh',
         \ 'vim': 'nvim --clean -ERM',
@@ -49,9 +49,13 @@ keys are:
 - `prefix` text that precedes all commands sent to the repl ('' to skip).
 - `suffix` text that follows all commands sent to the repl ('' to skip).
   Useful for ocaml, where one should set the suffix to `;;`.
+- `repl_type` unlocks different repl behaviors ('' uses default behavior).
+  Supported repl types are:
+  - `default`: sends lines, 1 at a time, to the repl for evaluation.
+  - `ipython`: similar to default, but uses system clipboard and %paste if
+    multiple lines are being sent to the repl.
 
-If its value is a String, the value is the `cmd`, and `prefix` / `suffix` are
-set to `''` (eg, there is no prefix / suffix).
+If its value is a String, the value is the `cmd`. All other options are `''`.
 
 *g:repl_default*
 Type: String | Dict[String | Dict]


### PR DESCRIPTION
User can now use ipython's native %paste functionality for multiple lines.

Should resolve https://github.com/pappasam/nvim-repl/issues/30